### PR TITLE
[ETHEREUM-CONTRACTS] Use account-level total deposit for CFA/GDA liquidation solvency

### DIFF
--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [UNRELEASED]
 
+### Fixed
+- CFA/GDA liquidation now uses account-level `totalDeposit` from `realtimeBalanceOf` (sum across agreements) instead of the per-agreement deposit.
+
 ### Breaking
 
 - **Monorepo:** Yarn 4 (`nodeLinker: node-modules`). Use `yarn install --immutable` (vendored via `.yarn/releases` / `yarnPath`; Nix exposes it on `PATH`).

--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -203,19 +203,18 @@ contract ConstantFlowAgreementV1 is
         public view override
         returns (bool)
     {
-        (int256 availableBalance, ,) = token.realtimeBalanceOf(account, timestamp);
+        (int256 availableBalance, uint256 totalDeposit,) = token.realtimeBalanceOf(account, timestamp);
         if (availableBalance >= 0) {
             return true;
         }
 
         (uint256 liquidationPeriod, uint256 patricianPeriod) =
             SolvencyHelperLibrary.decode3PsData(ISuperfluid(_host), token);
-        (,FlowData memory senderAccountState) = _getAccountFlowState(token, account);
-        int256 signedTotalCFADeposit = senderAccountState.deposit.toInt256();
 
+        // Account-level totalDeposit from realtimeBalanceOf (across agreements).
         return SolvencyHelperLibrary.isPatricianPeriod(
             availableBalance,
-            signedTotalCFADeposit,
+            totalDeposit.toInt256(),
             liquidationPeriod,
             patricianPeriod
         );
@@ -510,7 +509,8 @@ contract ConstantFlowAgreementV1 is
         (bool exist, FlowData memory oldFlowData) = _getAgreementData(flowVars.token, flowParams.flowId);
         if (!exist) revert CFA_FLOW_DOES_NOT_EXIST();
 
-        (int256 availableBalance,,) = flowVars.token.realtimeBalanceOf(flowVars.sender, currentContext.timestamp);
+        (int256 availableBalance, uint256 totalDeposit,) =
+            flowVars.token.realtimeBalanceOf(flowVars.sender, currentContext.timestamp);
 
         // delete should only be called by sender, receiver or flowOperator
         // unless it is a liquidation (availale balance < 0)
@@ -528,6 +528,7 @@ contract ConstantFlowAgreementV1 is
             _makeLiquidationPayouts(
                 flowVars.token,
                 availableBalance,
+                totalDeposit.toInt256(),
                 flowParams,
                 oldFlowData,
                 currentContext.msgSender);
@@ -1360,27 +1361,25 @@ contract ConstantFlowAgreementV1 is
     function _makeLiquidationPayouts(
         ISuperfluidToken token,
         int256 availableBalance,
+        int256 signedTotalDeposit,
         FlowParams memory flowParams,
         FlowData memory flowData,
         address liquidator
     )
         private
     {
-        (,FlowData memory senderAccountState) = _getAccountFlowState(token, flowParams.sender);
-
         int256 signedSingleDeposit = flowData.deposit.toInt256();
 
-        int256 signedTotalCFADeposit = senderAccountState.deposit.toInt256();
         bytes memory liquidationTypeData;
         bool isCurrentlyPatricianPeriod;
 
         // Liquidation rules:
         //    - let Available Balance = AB (is negative)
         //    -     Agreement Single Deposit = SD
-        //    -     Agreement Total Deposit = TD
+        //    -     Account Total Deposit = TD (sum of deposits across all agreements)
         //    -     Total Reward Left = RL = AB + TD
         // #1 Can the total account deposit still cover the available balance deficit?
-        int256 totalRewardLeft = availableBalance + signedTotalCFADeposit;
+        int256 totalRewardLeft = availableBalance + signedTotalDeposit;
 
         // To retrieve patrician period
         // Note: curly brackets are to handle stack too deep overflow issue
@@ -1389,7 +1388,7 @@ contract ConstantFlowAgreementV1 is
                 SolvencyHelperLibrary.decode3PsData(ISuperfluid(_host), token);
             isCurrentlyPatricianPeriod = SolvencyHelperLibrary.isPatricianPeriod(
                 availableBalance,
-                signedTotalCFADeposit,
+                signedTotalDeposit,
                 liquidationPeriod,
                 patricianPeriod
             );
@@ -1400,7 +1399,7 @@ contract ConstantFlowAgreementV1 is
             // the liquidator is always whoever triggers the liquidation, but the
             // account which receives the reward will depend on the period (Patrician or Pleb)
             // #1.a.1 yes: then reward = (SD / TD) * RL
-            int256 rewardAmount = signedSingleDeposit * totalRewardLeft / signedTotalCFADeposit;
+            int256 rewardAmount = signedSingleDeposit * totalRewardLeft / signedTotalDeposit;
             liquidationTypeData = abi.encode(1, isCurrentlyPatricianPeriod ? 0 : 1);
             token.makeLiquidationPayoutsV2(
                 flowParams.flowId, // id

--- a/packages/ethereum-contracts/contracts/agreements/gdav1/GeneralDistributionAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/gdav1/GeneralDistributionAgreementV1.sol
@@ -509,7 +509,7 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
         int256 availableBalance;
         address sender;
         bytes32 distributionFlowHash;
-        int256 signedTotalGDADeposit;
+        int256 signedTotalDeposit;
         address liquidator;
     }
 
@@ -570,7 +570,8 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
                     revert GDA_DISTRIBUTE_FOR_OTHERS_NOT_ALLOWED();
                 } else {
                     // liquidation case, requestedFlowRate == 0
-                    (int256 availableBalance,,) = token.realtimeBalanceOf(from, flowVars.currentContext.timestamp);
+                    (int256 availableBalance, uint256 totalDeposit,) =
+                        token.realtimeBalanceOf(from, flowVars.currentContext.timestamp);
                     // StackVarsLiquidation used to handle good ol' stack too deep
                     _StackVars_Liquidation memory liquidationData;
                     {
@@ -578,12 +579,16 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
                         liquidationData.sender = from;
                         liquidationData.liquidator = flowVars.currentContext.msgSender;
                         liquidationData.distributionFlowHash = flowVars.distributionFlowHash;
-                        // TODO: GeneralDistributionAgreementV1Storage may offer an function that reads only 1 word.
-                        liquidationData.signedTotalGDADeposit = token.getAccountData(this, from).totalBuffer.toInt256();
+                        // Account-level totalDeposit from realtimeBalanceOf (across agreements).
+                        liquidationData.signedTotalDeposit = totalDeposit.toInt256();
                         liquidationData.availableBalance = availableBalance;
                     }
                     // closing stream on behalf of someone else: liquidation case
                     if (availableBalance < 0) {
+                        // only liquidate if a GDA flow actually exists
+                        if (FlowRate.unwrap(flowVars.oldFlowRate) <= 0) {
+                            revert GDA_FLOW_DOES_NOT_EXIST();
+                        }
                         _makeLiquidationPayouts(liquidationData);
                     } else {
                         revert GDA_NON_CRITICAL_SENDER();
@@ -698,7 +703,7 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
         override
         returns (bool)
     {
-        (int256 availableBalance,,) = token.realtimeBalanceOf(account, timestamp);
+        (int256 availableBalance, uint256 totalDeposit,) = token.realtimeBalanceOf(account, timestamp);
         if (availableBalance >= 0) {
             return true;
         }
@@ -708,7 +713,7 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
 
         return SolvencyHelperLibrary.isPatricianPeriod(
             availableBalance,
-            token.getAccountData(this, account).totalBuffer.toInt256(),
+            totalDeposit.toInt256(),
             liquidationPeriod,
             patricianPeriod
         );
@@ -725,15 +730,15 @@ contract GeneralDistributionAgreementV1 is AgreementBase, TokenMonad, IGeneralDi
             (uint256 liquidationPeriod, uint256 patricianPeriod) =
                 SolvencyHelperLibrary.decode3PsData(ISuperfluid(_host), data.token);
             isCurrentlyPatricianPeriod = SolvencyHelperLibrary.isPatricianPeriod(
-                data.availableBalance, data.signedTotalGDADeposit, liquidationPeriod, patricianPeriod
+                data.availableBalance, data.signedTotalDeposit, liquidationPeriod, patricianPeriod
             );
         }
 
-        int256 totalRewardLeft = data.availableBalance + data.signedTotalGDADeposit;
+        int256 totalRewardLeft = data.availableBalance + data.signedTotalDeposit;
 
         // critical case
         if (totalRewardLeft >= 0) {
-            int256 rewardAmount = (signedSingleDeposit * totalRewardLeft) / data.signedTotalGDADeposit;
+            int256 rewardAmount = (signedSingleDeposit * totalRewardLeft) / data.signedTotalDeposit;
             data.token.makeLiquidationPayoutsV2(
                 data.distributionFlowHash,
                 abi.encode(2, isCurrentlyPatricianPeriod ? 0 : 1),

--- a/packages/ethereum-contracts/test/foundry/agreements/SolvencyLiquidation.t.sol
+++ b/packages/ethereum-contracts/test/foundry/agreements/SolvencyLiquidation.t.sol
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity ^0.8.23;
+
+import { SafeCast } from "@openzeppelin-v5/contracts/utils/math/SafeCast.sol";
+import "../FoundrySuperfluidTester.t.sol";
+import {
+    IGeneralDistributionAgreementV1,
+    PoolConfig
+} from "../../../contracts/interfaces/agreements/gdav1/IGeneralDistributionAgreementV1.sol";
+import { ISuperfluid } from "../../../contracts/interfaces/superfluid/ISuperfluid.sol";
+import { ISuperfluidPool } from "../../../contracts/agreements/gdav1/SuperfluidPool.sol";
+import { CFASuperAppBase } from "../../../contracts/apps/CFASuperAppBase.sol";
+import { SuperTokenV1Library } from "../../../contracts/apps/SuperTokenV1Library.sol";
+
+/// @dev Relays inbound CFA to a configured outbound CFA rate; optional GDA distribution.
+contract OwedDepositSuperApp is CFASuperAppBase {
+    using SuperTokenV1Library for ISuperToken;
+
+    address internal immutable _receiver;
+    int96 internal _outboundFlowRate;
+
+    constructor(ISuperfluid host, address receiver) CFASuperAppBase(host) {
+        _receiver = receiver;
+        selfRegister(true, false, false);
+    }
+
+    function setOutboundFlowRate(int96 outboundFlowRate) external {
+        _outboundFlowRate = outboundFlowRate;
+    }
+
+    function onFlowCreated(ISuperToken superToken, address, int96, bytes calldata ctx)
+        internal
+        override
+        returns (bytes memory newCtx)
+    {
+        if (_outboundFlowRate > 0) {
+            newCtx = superToken.createFlowWithCtx(_receiver, _outboundFlowRate, ctx);
+        } else {
+            newCtx = ctx;
+        }
+    }
+
+    function startDistributionFlow(ISuperToken superToken, ISuperfluidPool pool, int96 flowRate) external {
+        superToken.distributeFlow(pool, flowRate);
+    }
+
+    function transferAll(ISuperToken superToken, address receiver) external {
+        superToken.transfer(receiver, superToken.balanceOf(address(this)));
+    }
+}
+
+/// @title Solvency liquidation integration tests
+/// @notice CFA/GDA liquidation uses account-level `totalDeposit` from `realtimeBalanceOf`
+///         (sum across agreements). `owedDeposit` does not change that coverage threshold.
+///
+/// Terminology:
+/// - critical: `availableBalance < 0`
+/// - deposit-covered (CFA/GDA liquidation): `availableBalance + totalDeposit >= 0`
+/// - SuperToken solvent: `availableBalance + max(0, totalDeposit - owedDeposit) >= 0`
+///   (`isAccountSolvent`). With owedDeposit > 0 these can diverge: SuperToken-insolvent
+///   while still deposit-covered for liquidation (no bailout).
+contract SolvencyLiquidationTest is FoundrySuperfluidTester {
+    using SuperTokenV1Library for ISuperToken;
+    using SafeCast for uint256;
+
+    /// @dev Dominant/minor ratio so warping past minor-deposit coverage still leaves
+    ///      the account globally deposit-covered.
+    uint256 internal constant MIN_DOMINANT_FLOW_RATE_RATIO = 100;
+    uint256 internal constant MIN_MINOR_FLOW_RATE = 1_000_000_000_000;
+
+    struct AccountSnapshot {
+        int256 availableBalance;
+        uint256 totalDeposit;
+        uint256 totalOwedDeposit;
+        /// @dev `max(0, totalDeposit - owedDeposit)` — SuperToken solvency buffer only.
+        uint256 solvencyBuffer;
+        uint256 totalOutflowRate;
+    }
+
+    struct AppOwedDepositScenario {
+        OwedDepositSuperApp app;
+        ISuperfluidPool pool;
+        AccountSnapshot snap;
+        uint256 cfaDeposit;
+        uint256 gdaDeposit;
+    }
+
+    struct BalancePair {
+        int256 reward;
+        int256 liquidator;
+    }
+
+    constructor() FoundrySuperfluidTester(10) { }
+
+    function _solvencyBuffer(uint256 totalDeposit, uint256 totalOwedDeposit) internal pure returns (uint256) {
+        return totalDeposit > totalOwedDeposit ? totalDeposit - totalOwedDeposit : 0;
+    }
+
+    function _snapshot(address account) internal view returns (AccountSnapshot memory snap) {
+        (snap.availableBalance, snap.totalDeposit, snap.totalOwedDeposit,) = superToken.realtimeBalanceOfNow(account);
+        snap.solvencyBuffer = _solvencyBuffer(snap.totalDeposit, snap.totalOwedDeposit);
+        int96 netFlowRate = superToken.getNetFlowRate(account);
+        if (netFlowRate < 0) {
+            snap.totalOutflowRate = uint256(uint96(-netFlowRate));
+        }
+    }
+
+    function _balances(address rewardAccount, address liquidator) internal view returns (BalancePair memory b) {
+        (b.reward,,,) = superToken.realtimeBalanceOfNow(rewardAccount);
+        (b.liquidator,,,) = superToken.realtimeBalanceOfNow(liquidator);
+    }
+
+    function _rewardAccount() internal view returns (address) {
+        return sf.governance.getRewardAddress(sf.host, superToken);
+    }
+
+    function _helperBoundValidFlowRate(int96 seed) internal pure returns (int96 flowRate) {
+        flowRate = int96(uint96(bound(uint256(int256(seed)), MIN_MINOR_FLOW_RATE, uint256(type(uint64).max))));
+    }
+
+    function _helperLiquidateGDAFlow(address liquidator, address sender, ISuperfluidPool pool) internal {
+        vm.startPrank(liquidator);
+        sf.host.callAgreement(
+            sf.gda, abi.encodeCall(sf.gda.distributeFlow, (superToken, sender, pool, 0, new bytes(0))), new bytes(0)
+        );
+        vm.stopPrank();
+    }
+
+    function _helperLiquidateCFAFlow(address liquidator, address sender, address receiver) internal {
+        vm.startPrank(liquidator);
+        superToken.deleteFlow(sender, receiver);
+        vm.stopPrank();
+    }
+
+    function _helperBoundDominantMinorFlowRates(int96 dominantSeed, int96 minorSeed)
+        internal
+        pure
+        returns (int96 dominant, int96 minor)
+    {
+        uint256 maxFlowRate = uint256(type(uint64).max);
+        uint256 dominantU =
+            bound(uint256(int256(dominantSeed)), MIN_DOMINANT_FLOW_RATE_RATIO * MIN_MINOR_FLOW_RATE, maxFlowRate);
+        uint256 minorU =
+            bound(uint256(int256(minorSeed)), MIN_MINOR_FLOW_RATE, dominantU / MIN_DOMINANT_FLOW_RATE_RATIO);
+        dominant = int96(uint96(dominantU));
+        minor = int96(uint96(minorU));
+    }
+
+    /// @dev CFA to carol + GDA to a pool (bob member); clears Alice's spendable balance.
+    function _helperSetupAliceCfaAndGdaOutflows(int96 cfaFlowRate, int96 gdaFlowRate)
+        internal
+        returns (ISuperfluidPool pool, uint256 cfaDeposit, uint256 gdaDeposit, uint256 totalOutflowRate)
+    {
+        pool = _helperCreatePool(superToken, alice, alice, false, poolConfig);
+        _helperConnectPool(bob, superToken, pool);
+        _helperUpdateMemberUnits(pool, alice, bob, 1);
+        _helperCreateFlow(superToken, alice, carol, cfaFlowRate);
+        _helperDistributeFlow(superToken, alice, alice, pool, gdaFlowRate);
+
+        uint256 totalDeposit;
+        (, totalDeposit,,) = superToken.realtimeBalanceOfNow(alice);
+        cfaDeposit = _helperGetAccountFlowInfo(superToken, alice).deposit;
+        gdaDeposit = totalDeposit - cfaDeposit;
+        totalOutflowRate = uint256(uint96(-superToken.getNetFlowRate(alice)));
+
+        vm.startPrank(alice);
+        superToken.transfer(dan, superToken.balanceOf(alice));
+        vm.stopPrank();
+    }
+
+    /// @dev Super App with inbound CFA (app credit / OD), partial outbound CFA, and GDA.
+    ///      Outbound is in (0, inflow/2] so OD is strictly below inbound credit capacity.
+    function _helperSetupAppOwedDepositScenario(int96 inflowSeed, int96 outboundSeed, int96 gdaSeed)
+        internal
+        returns (AppOwedDepositScenario memory scenario)
+    {
+        uint256 maxFlowRate = uint256(type(uint64).max);
+        uint256 maxInflow = maxFlowRate / 2;
+        int96 inflowRate = int96(uint96(bound(uint256(int256(inflowSeed)), MIN_MINOR_FLOW_RATE, maxInflow)));
+        uint256 inflowU = uint256(uint96(inflowRate));
+        uint256 outboundU = bound(uint256(int256(outboundSeed)), 1, inflowU / 2 == 0 ? 1 : inflowU / 2);
+        int96 outboundRate = int96(uint96(outboundU));
+
+        // Negative net flow after emptying; keep a non-empty window where SuperToken is
+        // insolvent (solvency buffer exhausted) but totalDeposit still covers.
+        uint256 minGda = inflowU > outboundU ? inflowU - outboundU + MIN_MINOR_FLOW_RATE : MIN_MINOR_FLOW_RATE;
+        uint256 maxGda = minGda + outboundU;
+        if (maxGda > maxFlowRate) maxGda = maxFlowRate;
+        int96 gdaFlowRate = int96(uint96(bound(uint256(int256(gdaSeed)), minGda, maxGda)));
+
+        scenario.app = new OwedDepositSuperApp(sf.host, carol);
+        _addAccount(address(scenario.app));
+        scenario.app.setOutboundFlowRate(outboundRate);
+
+        scenario.pool = _helperCreatePool(superToken, alice, alice, false, poolConfig);
+        _helperConnectPool(bob, superToken, scenario.pool);
+        _helperUpdateMemberUnits(scenario.pool, alice, bob, 1);
+
+        vm.startPrank(alice);
+        superToken.transfer(address(scenario.app), 1e24);
+        superToken.createFlow(address(scenario.app), inflowRate);
+        vm.stopPrank();
+
+        scenario.app.startDistributionFlow(superToken, scenario.pool, gdaFlowRate);
+        uint256 inflowDeposit;
+        (,, inflowDeposit,) = superToken.getFlowInfo(alice, address(scenario.app));
+        (,, scenario.cfaDeposit,) = superToken.getFlowInfo(address(scenario.app), carol);
+        (,, scenario.gdaDeposit) = sf.gda.getFlow(superToken, address(scenario.app), scenario.pool);
+
+        scenario.app.transferAll(superToken, dan);
+        scenario.snap = _snapshot(address(scenario.app));
+        assertGt(scenario.snap.totalOwedDeposit, 0, "expected owed deposit");
+        assertGt(scenario.snap.totalOutflowRate, 0, "expected net outflow");
+        assertGt(scenario.snap.totalDeposit, scenario.snap.solvencyBuffer, "OD should shrink solvency buffer");
+        assertLt(scenario.snap.totalOwedDeposit, inflowDeposit, "partial OD expected");
+    }
+
+    /// @dev CFA-only Super App: inbound CFA creates OD; larger outbound CFA creates net drain.
+    function _helperSetupPureCFAAppCreditScenario() internal returns (AppOwedDepositScenario memory scenario) {
+        int96 inflowRate = 100_000_000_000_000;
+        int96 outboundRate = 150_000_000_000_000;
+
+        scenario.app = new OwedDepositSuperApp(sf.host, carol);
+        _addAccount(address(scenario.app));
+        scenario.app.setOutboundFlowRate(outboundRate);
+
+        vm.startPrank(alice);
+        superToken.transfer(address(scenario.app), 1e24);
+        superToken.createFlow(address(scenario.app), inflowRate);
+        vm.stopPrank();
+
+        (,, scenario.cfaDeposit,) = superToken.getFlowInfo(address(scenario.app), carol);
+
+        scenario.app.transferAll(superToken, dan);
+        scenario.snap = _snapshot(address(scenario.app));
+        assertGt(scenario.snap.totalOwedDeposit, 0, "expected owed deposit");
+        assertGt(scenario.snap.totalDeposit, scenario.snap.solvencyBuffer, "OD should shrink solvency buffer");
+        assertGt(scenario.snap.totalOutflowRate, 0, "expected CFA-only net outflow");
+    }
+
+    /// @dev Warp into the deposit-covered critical window, capped to stay patrician.
+    function _warpSecondsIntoCoverageWindow(AccountSnapshot memory snap, uint256 warpSeed) internal {
+        require(snap.totalDeposit > 0 && snap.totalOutflowRate > 0, "coverage window requires buffer");
+        uint256 maxCoveredSeconds = snap.totalDeposit / snap.totalOutflowRate;
+        require(maxCoveredSeconds > 0, "total deposit too small for coverage window");
+
+        (, uint256 patricianPeriod) = sf.governance.getPPPConfig(sf.host, superToken);
+        // Patrician uses deposit/liquidationPeriod as implied outflow; wall-clock coverage can exceed
+        // that window when inflows offset net drain. Cap so reward stays with the reward account.
+        uint256 maxWarp = maxCoveredSeconds;
+        if (patricianPeriod > 0 && patricianPeriod - 1 < maxWarp) {
+            maxWarp = patricianPeriod - 1;
+        }
+        require(maxWarp > 0, "patrician coverage window empty");
+
+        uint256 maxSafeWarp = type(uint32).max - block.timestamp - 1;
+        if (maxWarp > maxSafeWarp) maxWarp = maxSafeWarp;
+        vm.warp(block.timestamp + bound(warpSeed, 1, maxWarp));
+    }
+
+    function _warpToInsolvency(AccountSnapshot memory snap) internal {
+        require(snap.totalOutflowRate > 0, "insolvency warp requires outflow");
+        uint256 warpSeconds = snap.totalDeposit / snap.totalOutflowRate + 1;
+        uint256 maxSafeWarp = type(uint32).max - block.timestamp - 1;
+        require(warpSeconds <= maxSafeWarp, "warp exceeds uint32 timestamp domain");
+        vm.warp(block.timestamp + warpSeconds);
+    }
+
+    /// @dev Past SuperToken solvency (`AB + solvencyBuffer < 0`) while still deposit-covered
+    ///      for CFA/GDA (`AB + totalDeposit >= 0`). Requires owedDeposit > 0.
+    function _warpPastSolvencyBufferWhileDepositCovered(AccountSnapshot memory snap) internal {
+        require(snap.totalOutflowRate > 0, "warp requires outflow");
+        require(snap.totalDeposit > snap.solvencyBuffer, "requires owed deposit");
+        uint256 solvencyCoveredSeconds = snap.solvencyBuffer / snap.totalOutflowRate;
+        uint256 depositCoveredSeconds = snap.totalDeposit / snap.totalOutflowRate;
+        vm.assume(depositCoveredSeconds > solvencyCoveredSeconds);
+        uint256 warpSeconds = solvencyCoveredSeconds + 1;
+        uint256 maxSafeWarp = type(uint32).max - block.timestamp - 1;
+        vm.assume(warpSeconds <= maxSafeWarp);
+        vm.warp(block.timestamp + warpSeconds);
+    }
+
+    function _expectedCriticalReward(uint256 singleDeposit, AccountSnapshot memory snap)
+        internal
+        pure
+        returns (int256)
+    {
+        return singleDeposit.toInt256() * (snap.availableBalance + snap.totalDeposit.toInt256())
+            / snap.totalDeposit.toInt256();
+    }
+
+    function _assertCriticalAndCovered(AccountSnapshot memory snap) internal pure {
+        assertLt(snap.availableBalance, 0, "critical");
+        assertGe(snap.availableBalance + snap.totalDeposit.toInt256(), 0, "deposit-covered");
+    }
+
+    function _assertCriticalAndInsolvent(AccountSnapshot memory snap) internal pure {
+        assertLt(snap.availableBalance, 0, "critical");
+        assertLt(snap.availableBalance + snap.totalDeposit.toInt256(), 0, "deposit-uncovered");
+    }
+
+    function _assertDepositCoveredButSuperTokenInsolvent(AccountSnapshot memory snap) internal pure {
+        assertLt(snap.availableBalance + snap.solvencyBuffer.toInt256(), 0, "SuperToken insolvent");
+        assertGe(snap.availableBalance + snap.totalDeposit.toInt256(), 0, "still deposit-covered");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Cross-agreement
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testRevertGDALiquidateCriticalSenderWithoutGDAFlow(PoolConfig memory config) public {
+        ISuperfluidPool pool = _helperCreatePool(superToken, alice, alice, false, config);
+
+        vm.startPrank(alice);
+        superToken.createFlow(bob, 100_000_000_000_000);
+        superToken.transfer(dan, superToken.balanceOf(alice));
+        vm.stopPrank();
+
+        _helperWarpToCritical(superToken, alice, 1);
+
+        vm.startPrank(carol);
+        vm.expectRevert(IGeneralDistributionAgreementV1.GDA_FLOW_DOES_NOT_EXIST.selector);
+        sf.host.callAgreement(
+            sf.gda, abi.encodeCall(sf.gda.distributeFlow, (superToken, alice, pool, 0, new bytes(0))), new bytes(0)
+        );
+        vm.stopPrank();
+    }
+
+    function testGDARewardAccountNotDebitedWhenAccountGloballyDepositCovered(int96 cfaFlowRate, int96 gdaFlowRate)
+        public
+    {
+        (cfaFlowRate, gdaFlowRate) = _helperBoundDominantMinorFlowRates(cfaFlowRate, gdaFlowRate);
+        (ISuperfluidPool pool,, uint256 gdaDeposit, uint256 totalOutflowRate) =
+            _helperSetupAliceCfaAndGdaOutflows(cfaFlowRate, gdaFlowRate);
+
+        vm.warp(block.timestamp + gdaDeposit / totalOutflowRate + 1);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        assertLt(gdaDeposit.toInt256(), -snap.availableBalance, "GDA deposit alone should not cover");
+        (bool isPatricianPeriod,) = sf.gda.isPatricianPeriodNow(superToken, alice);
+        assertTrue(isPatricianPeriod, "patrician");
+
+        int256 expectedReward = _expectedCriticalReward(gdaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateGDAFlow(eve, alice, pool);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward + expectedReward, "incorrect GDA patrician reward");
+        assertEq(afterBalances.liquidator, beforeBalances.liquidator, "liquidator should not receive patrician reward");
+    }
+
+    function testGDAGloballyCoveredPlebRewardGoesToLiquidator() public {
+        (ISuperfluidPool pool,, uint256 gdaDeposit,) =
+            _helperSetupAliceCfaAndGdaOutflows(200_000_000_000_000, 100_000_000_000_000);
+        (, uint256 patricianPeriod) = sf.governance.getPPPConfig(sf.host, superToken);
+        vm.warp(block.timestamp + patricianPeriod + 1);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        (bool isPatricianPeriod,) = sf.gda.isPatricianPeriodNow(superToken, alice);
+        assertFalse(isPatricianPeriod, "pleb");
+
+        int256 expectedReward = _expectedCriticalReward(gdaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateGDAFlow(eve, alice, pool);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward, "reward account should not receive pleb reward");
+        assertEq(afterBalances.liquidator, beforeBalances.liquidator + expectedReward, "incorrect GDA pleb reward");
+    }
+
+    function testGDARewardAccountDebitedWhenAccountGloballyInsolvent(int96 cfaSeed, int96 gdaSeed) public {
+        (ISuperfluidPool pool,, uint256 gdaDeposit,) =
+            _helperSetupAliceCfaAndGdaOutflows(_helperBoundValidFlowRate(cfaSeed), _helperBoundValidFlowRate(gdaSeed));
+        _warpToInsolvency(_snapshot(alice));
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndInsolvent(snap);
+        int256 bailoutAmount = -(snap.availableBalance + snap.totalDeposit.toInt256());
+
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateGDAFlow(eve, alice, pool);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        (int256 senderAfter,,,) = superToken.realtimeBalanceOfNow(alice);
+        assertEq(
+            afterBalances.reward,
+            beforeBalances.reward - gdaDeposit.toInt256() - bailoutAmount,
+            "incorrect GDA bailout debit"
+        );
+        assertEq(
+            afterBalances.liquidator,
+            beforeBalances.liquidator + gdaDeposit.toInt256(),
+            "incorrect GDA liquidator reward"
+        );
+        assertEq(senderAfter, gdaDeposit.toInt256() - snap.totalDeposit.toInt256(), "incorrect sender bailout AB");
+        assertTrue(superToken.isAccountSolventNow(alice), "GDA bailout should restore solvency");
+    }
+
+    function testCFARewardAccountNotDebitedWhenAccountGloballyDepositCovered(int96 cfaFlowRate, int96 gdaFlowRate)
+        public
+    {
+        (gdaFlowRate, cfaFlowRate) = _helperBoundDominantMinorFlowRates(gdaFlowRate, cfaFlowRate);
+        (, uint256 cfaDeposit,, uint256 totalOutflowRate) = _helperSetupAliceCfaAndGdaOutflows(cfaFlowRate, gdaFlowRate);
+
+        vm.warp(block.timestamp + cfaDeposit / totalOutflowRate + 1);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        assertLt(cfaDeposit.toInt256(), -snap.availableBalance, "CFA deposit alone should not cover");
+        (bool isPatricianPeriod,) = sf.cfa.isPatricianPeriodNow(superToken, alice);
+        assertTrue(isPatricianPeriod, "patrician");
+
+        int256 expectedReward = _expectedCriticalReward(cfaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateCFAFlow(eve, alice, carol);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward + expectedReward, "incorrect CFA patrician reward");
+        assertEq(afterBalances.liquidator, beforeBalances.liquidator, "liquidator should not receive patrician reward");
+    }
+
+    function testCFAGloballyCoveredPlebRewardGoesToLiquidator() public {
+        (, uint256 cfaDeposit,,) = _helperSetupAliceCfaAndGdaOutflows(100_000_000_000_000, 200_000_000_000_000);
+        (, uint256 patricianPeriod) = sf.governance.getPPPConfig(sf.host, superToken);
+        vm.warp(block.timestamp + patricianPeriod + 1);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        (bool isPatricianPeriod,) = sf.cfa.isPatricianPeriodNow(superToken, alice);
+        assertFalse(isPatricianPeriod, "pleb");
+
+        int256 expectedReward = _expectedCriticalReward(cfaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateCFAFlow(eve, alice, carol);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward, "reward account should not receive pleb reward");
+        assertEq(afterBalances.liquidator, beforeBalances.liquidator + expectedReward, "incorrect CFA pleb reward");
+    }
+
+    function testCFARewardAccountDebitedWhenAccountGloballyInsolvent(int96 cfaSeed, int96 gdaSeed) public {
+        (, uint256 cfaDeposit,,) =
+            _helperSetupAliceCfaAndGdaOutflows(_helperBoundValidFlowRate(cfaSeed), _helperBoundValidFlowRate(gdaSeed));
+        _warpToInsolvency(_snapshot(alice));
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndInsolvent(snap);
+        int256 bailoutAmount = -(snap.availableBalance + snap.totalDeposit.toInt256());
+
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateCFAFlow(eve, alice, carol);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        (int256 senderAfter,,,) = superToken.realtimeBalanceOfNow(alice);
+        assertEq(
+            afterBalances.reward,
+            beforeBalances.reward - cfaDeposit.toInt256() - bailoutAmount,
+            "incorrect CFA bailout debit"
+        );
+        assertEq(
+            afterBalances.liquidator,
+            beforeBalances.liquidator + cfaDeposit.toInt256(),
+            "incorrect CFA liquidator reward"
+        );
+        assertEq(senderAfter, cfaDeposit.toInt256() - snap.totalDeposit.toInt256(), "incorrect sender bailout AB");
+        assertTrue(superToken.isAccountSolventNow(alice), "CFA bailout should restore solvency");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Multi-flow reward share
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testCFAMultiFlowCriticalRewardUsesAccountTotalDeposit(
+        int96 rate1Seed,
+        int96 rate2Seed,
+        uint256 warpSeed
+    ) public {
+        _helperCreateFlow(superToken, alice, carol, _helperBoundValidFlowRate(rate1Seed));
+        _helperCreateFlow(superToken, alice, frank, _helperBoundValidFlowRate(rate2Seed));
+        vm.startPrank(alice);
+        superToken.transfer(dan, superToken.balanceOf(alice));
+        vm.stopPrank();
+
+        _warpSecondsIntoCoverageWindow(_snapshot(alice), warpSeed);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        (,, uint256 flow1Deposit,) = superToken.getFlowInfo(alice, carol);
+
+        int256 expectedReward = _expectedCriticalReward(flow1Deposit, snap);
+        address rewardAccount = _rewardAccount();
+        (int256 rewardBefore,,,) = superToken.realtimeBalanceOfNow(rewardAccount);
+
+        _helperLiquidateCFAFlow(eve, alice, carol);
+
+        (int256 rewardAfter,,,) = superToken.realtimeBalanceOfNow(rewardAccount);
+        assertEq(rewardAfter, rewardBefore + expectedReward, "incorrect multi-flow CFA reward share");
+        assertGt(superToken.getFlowRate(alice, frank), 0, "second CFA flow should remain open");
+    }
+
+    function testGDAMultiFlowCriticalRewardUsesAccountTotalDeposit(
+        int96 rate1Seed,
+        int96 rate2Seed,
+        uint256 warpSeed
+    ) public {
+        int96 rate1 = _helperBoundValidFlowRate(rate1Seed);
+        int96 rate2 = _helperBoundValidFlowRate(rate2Seed);
+
+        ISuperfluidPool pool1 = _helperCreatePool(superToken, alice, alice, false, poolConfig);
+        ISuperfluidPool pool2 = _helperCreatePool(superToken, alice, alice, false, poolConfig);
+        _helperConnectPool(bob, superToken, pool1);
+        _helperConnectPool(bob, superToken, pool2);
+        _helperUpdateMemberUnits(pool1, alice, bob, 1);
+        _helperUpdateMemberUnits(pool2, alice, bob, 1);
+        _helperDistributeFlow(superToken, alice, alice, pool1, rate1);
+        _helperDistributeFlow(superToken, alice, alice, pool2, rate2);
+
+        vm.startPrank(alice);
+        superToken.transfer(dan, superToken.balanceOf(alice));
+        vm.stopPrank();
+
+        _warpSecondsIntoCoverageWindow(_snapshot(alice), warpSeed);
+
+        AccountSnapshot memory snap = _snapshot(alice);
+        _assertCriticalAndCovered(snap);
+        (,, uint256 flow1Deposit) = sf.gda.getFlow(superToken, alice, pool1);
+
+        int256 expectedReward = _expectedCriticalReward(flow1Deposit, snap);
+        address rewardAccount = _rewardAccount();
+        (int256 rewardBefore,,,) = superToken.realtimeBalanceOfNow(rewardAccount);
+
+        _helperLiquidateGDAFlow(eve, alice, pool1);
+
+        (int256 rewardAfter,,,) = superToken.realtimeBalanceOfNow(rewardAccount);
+        assertEq(rewardAfter, rewardBefore + expectedReward, "incorrect multi-flow GDA reward share");
+        assertGt(sf.gda.getFlowRate(superToken, alice, pool2), 0, "second GDA flow should remain open");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    SuperToken insolvency vs CFA/GDA deposit coverage
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev SuperToken insolvent via owedDeposit, but GDA liquidation stays deposit-covered
+    ///      (no reward-account bailout).
+    function testAppGDACoveredWhenOwedDepositMakesAccountSuperTokenInsolvent(
+        int96 inflowSeed,
+        int96 outboundSeed,
+        int96 gdaSeed
+    ) public {
+        AppOwedDepositScenario memory scenario = _helperSetupAppOwedDepositScenario(inflowSeed, outboundSeed, gdaSeed);
+
+        _warpPastSolvencyBufferWhileDepositCovered(scenario.snap);
+        AccountSnapshot memory snap = _snapshot(address(scenario.app));
+        _assertDepositCoveredButSuperTokenInsolvent(snap);
+
+        int256 expectedReward = _expectedCriticalReward(scenario.gdaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateGDAFlow(eve, address(scenario.app), scenario.pool);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward, "no bailout while deposit-covered");
+        assertEq(
+            afterBalances.liquidator,
+            beforeBalances.liquidator + expectedReward,
+            "GDA covered reward despite SuperToken insolvency"
+        );
+    }
+
+    /// @dev Same split for a CFA-only Super App (minimal setup).
+    function testPureCFACoveredWhenAppCreditMakesAccountSuperTokenInsolvent() public {
+        AppOwedDepositScenario memory scenario = _helperSetupPureCFAAppCreditScenario();
+
+        _warpPastSolvencyBufferWhileDepositCovered(scenario.snap);
+        AccountSnapshot memory snap = _snapshot(address(scenario.app));
+        assertLt(snap.availableBalance, 0, "critical");
+        _assertDepositCoveredButSuperTokenInsolvent(snap);
+
+        int256 expectedReward = _expectedCriticalReward(scenario.cfaDeposit, snap);
+        address rewardAccount = _rewardAccount();
+        BalancePair memory beforeBalances = _balances(rewardAccount, eve);
+
+        _helperLiquidateCFAFlow(eve, address(scenario.app), carol);
+
+        BalancePair memory afterBalances = _balances(rewardAccount, eve);
+        assertEq(afterBalances.reward, beforeBalances.reward, "no bailout while deposit-covered");
+        assertEq(
+            afterBalances.liquidator,
+            beforeBalances.liquidator + expectedReward,
+            "pure CFA covered reward despite SuperToken insolvency"
+        );
+    }
+}

--- a/packages/hot-fuzz/contracts/HotFuzzBase.sol
+++ b/packages/hot-fuzz/contracts/HotFuzzBase.sol
@@ -3,6 +3,7 @@
 // solhint-disable func-name-mixedcase
 pragma solidity >= 0.8.0;
 
+import { Vm } from "forge-std/Vm.sol";
 import { TestToken } from "@superfluid-finance/ethereum-contracts/contracts/utils/TestToken.sol";
 import { ISuperfluid, Superfluid } from "@superfluid-finance/ethereum-contracts/contracts/superfluid/Superfluid.sol";
 import { SuperToken } from "@superfluid-finance/ethereum-contracts/contracts/superfluid/SuperToken.sol";
@@ -25,6 +26,11 @@ import {
 
 contract HotFuzzBase {
     using SuperTokenV1Library for SuperToken;
+
+    // Minimal hevm cheatcode access (avoid inheriting forge-std Test under Echidna).
+    // solhint-disable-next-line const-name-snakecase
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     // constants
     uint private constant INIT_TOKEN_BALANCE = type(uint160).max;
     uint private constant INIT_SUPER_TOKEN_BALANCE = type(uint128).max;
@@ -42,6 +48,16 @@ contract HotFuzzBase {
     address[] internal otherAccounts;
     uint256 internal expectedTotalSupply = 0;
     bool internal liquidationFails;
+    // Set by CFA/GDA liquidation actions when post-conditions fail. Property-mode Echidna
+    // only observes echidna_* flags — inline asserts would be discarded.
+    bool internal liquidationPostconditionViolated;
+
+    struct LiquidationExpectations {
+        bool isCritical;
+        address rewardAccount;
+        int256 rewardAccountAfter;
+        int256 liquidatorAfter;
+    }
 
     constructor(uint nTesters_) {
         _sfDeployer = new SuperfluidFrameworkDeployer();
@@ -101,7 +117,7 @@ contract HotFuzzBase {
         internal view
         returns (SuperfluidTester tester)
     {
-        tester = testers[a % _numAccounts()];
+        tester = testers[a % nTesters];
     }
 
     /// @dev The testers returned may be the same
@@ -125,6 +141,83 @@ contract HotFuzzBase {
 
     function _superTokenBalanceOfNow(address a) internal view returns (int256 avb) {
         (avb,,,) = superToken.realtimeBalanceOfNow(a);
+    }
+
+    function _getLiquidationExpectations(
+        address account,
+        address liquidator,
+        uint256 singleDeposit,
+        bool isPatricianPeriod
+    ) internal view returns (LiquidationExpectations memory expectations) {
+        (int256 availableBalance, uint256 totalDeposit,,) = superToken.realtimeBalanceOfNow(account);
+        expectations.isCritical = availableBalance < 0;
+        expectations.rewardAccount = sf.governance.getRewardAddress(sf.host, superToken);
+        (expectations.rewardAccountAfter,,,) =
+            superToken.realtimeBalanceOfNow(expectations.rewardAccount);
+        (expectations.liquidatorAfter,,,) = superToken.realtimeBalanceOfNow(liquidator);
+        if (!expectations.isCritical) return expectations;
+
+        // Account-level totalDeposit from realtimeBalanceOf (across agreements).
+        int256 signedTotalDeposit = int256(totalDeposit);
+        int256 totalRewardLeft = availableBalance + signedTotalDeposit;
+        if (totalRewardLeft >= 0) {
+            int256 reward = int256(singleDeposit) * totalRewardLeft / signedTotalDeposit;
+            if (isPatricianPeriod) {
+                expectations.rewardAccountAfter += reward;
+            } else {
+                expectations.liquidatorAfter += reward;
+            }
+        } else {
+            expectations.rewardAccountAfter += totalRewardLeft - int256(singleDeposit);
+            expectations.liquidatorAfter += int256(singleDeposit);
+        }
+    }
+
+    /// @dev CFA/GDA pack timestamps as uint32; never leave that domain.
+    function _warpBy(uint256 dt) private {
+        if (dt == 0) return;
+        uint256 maxTs = type(uint32).max;
+        if (block.timestamp >= maxTs) return;
+        uint256 room = maxTs - block.timestamp;
+        if (dt > room) dt = room;
+        vm.warp(block.timestamp + dt);
+    }
+
+    function warpTime(uint32 seconds_) public {
+        if (seconds_ == 0) return;
+        uint256 dt = uint256(seconds_) % 7 days;
+        if (dt == 0) dt = 1;
+        _warpBy(dt);
+    }
+
+    /// @notice Bring tester `a` to a critical available balance if it has net outflow.
+    /// @dev Testers start with ~2^128 tokens. Waiting for flow alone to drain that can
+    ///      exceed the uint32 timestamp domain and break dynamic balances / liquidity-sum.
+    ///      Drain spendable balance to another tester first (preserves total liquidity),
+    ///      then warp a short bounded time — same setup pattern as the Foundry solvency tests.
+    function warpToCritical(uint8 a, uint32 secondsAfterCritical) public {
+        SuperfluidTester tester = _getOneTester(a);
+        if (superToken.getNetFlowRate(address(tester)) >= 0) return;
+
+        SuperfluidTester sink = _getOneTester(a + 1);
+        if (address(sink) != address(tester)) {
+            tester.transferAll(address(sink));
+        }
+
+        uint256 dt = uint256(secondsAfterCritical) % 1 days;
+        if (dt == 0) dt = 1;
+        _warpBy(dt);
+    }
+
+    function _checkLiquidationBalances(LiquidationExpectations memory expectations, address liquidator)
+        internal
+        view
+        returns (bool ok)
+    {
+        (int256 rewardAccountAfter,,,) = superToken.realtimeBalanceOfNow(expectations.rewardAccount);
+        (int256 liquidatorAfter,,,) = superToken.realtimeBalanceOfNow(liquidator);
+        return rewardAccountAfter == expectations.rewardAccountAfter
+            && liquidatorAfter == expectations.liquidatorAfter;
     }
 
     /**************************************************************************
@@ -164,5 +257,11 @@ contract HotFuzzBase {
         bool liquidationNeverFails = !liquidationFails;
         assert(liquidationNeverFails);
         return liquidationNeverFails;
+    }
+
+    function echidna_check_liquidationPostconditions() public view returns (bool) {
+        bool ok = !liquidationPostconditionViolated;
+        assert(ok);
+        return ok;
     }
 }

--- a/packages/hot-fuzz/contracts/superfluid-tests/ConstantFlowAgreementV1.hott.sol
+++ b/packages/hot-fuzz/contracts/superfluid-tests/ConstantFlowAgreementV1.hott.sol
@@ -23,25 +23,28 @@ abstract contract CFAHotFuzzMixin is HotFuzzBase {
     }
 
     /// @notice testerA liquidates a flow from testerB to testerC
-    /// @dev testerA can be the same as testerB or testerC
+    /// @dev Self-liquidate (A == B) is allowed; reward balance asserts are skipped in that case
+    ///      because sender and liquidator are the same account.
     function cfaLiquidateFlow(uint8 a, uint8 b, uint8 c) public {
         (SuperfluidTester liquidator, SuperfluidTester sender, SuperfluidTester recipient) = _getThreeTesters(a, b, c);
 
-        // we first check the condition for whether a flow exists
         bool flowExists = superToken.getFlowRate(address(sender), address(recipient)) > 0;
+        (,, uint256 singleDeposit,) = superToken.getFlowInfo(address(sender), address(recipient));
+        (bool isPatricianPeriod,) = sf.cfa.isPatricianPeriodNow(superToken, address(sender));
+        LiquidationExpectations memory expectations =
+            _getLiquidationExpectations(address(sender), address(liquidator), singleDeposit, isPatricianPeriod);
 
-        // then we ensure that the sender has a critical balance
-        (int256 availableBalance,,,) = superToken.realtimeBalanceOfNow(address(sender));
-        bool isSenderCritical = availableBalance < 0;
+        if (!(flowExists && expectations.isCritical)) return;
 
-        // if both conditions are met, a liquidation should occur without fail
-        bool isLiquidationValid = flowExists && isSenderCritical;
-        if (isLiquidationValid) {
-            // solhint-disable-next-line no-empty-blocks
-            try liquidator.cfaLiquidate(address(sender), address(recipient)) {}
-            catch {
-                liquidationFails = true;
+        bool selfLiquidate = address(liquidator) == address(sender);
+        try liquidator.cfaLiquidate(address(sender), address(recipient)) {
+            if (superToken.getFlowRate(address(sender), address(recipient)) != 0) {
+                liquidationPostconditionViolated = true;
+            } else if (!selfLiquidate && !_checkLiquidationBalances(expectations, address(liquidator))) {
+                liquidationPostconditionViolated = true;
             }
+        } catch {
+            liquidationFails = true;
         }
     }
 

--- a/packages/hot-fuzz/contracts/superfluid-tests/GeneralDistributionAgreementV1.hott.sol
+++ b/packages/hot-fuzz/contracts/superfluid-tests/GeneralDistributionAgreementV1.hott.sol
@@ -16,9 +16,8 @@ abstract contract GDAHotFuzzMixin is HotFuzzBase {
     ISuperfluidPool[] public pools;
 
     function getRandomPool(uint8 input) public view returns (ISuperfluidPool pool) {
-        if (pools.length > 0) {
-            pool = pools[input % (pools.length - 1)];
-        }
+        // GDAHotFuzz / SuperHotFuzz constructors always seed pools; length only grows via createPool.
+        pool = pools[input % pools.length];
     }
 
     function createPool(uint8 a, PoolConfig memory config) public {
@@ -52,26 +51,30 @@ abstract contract GDAHotFuzzMixin is HotFuzzBase {
     }
 
     /// @notice testerA liquidates a flow from testerB to pool
-    /// @dev testerA can be the same as testerB
+    /// @dev Skips when liquidator == distributor (self-liquidate not exercised here).
     function gdaLiquidateFlow(uint8 a, uint8 b, uint8 c) public {
         (SuperfluidTester liquidator, SuperfluidTester distributor) = _getTwoTesters(a, b);
+        if (address(liquidator) == address(distributor)) return;
         ISuperfluidPool pool = getRandomPool(c);
+        if (address(pool) == address(0)) return;
 
-        // we first check the condition for whether a flow exists
         bool flowExists = superToken.getFlowDistributionFlowRate(address(distributor), pool) > 0;
+        (,, uint256 singleDeposit,) =
+            superToken.getFlowInfo(address(distributor), address(pool));
+        (bool isPatricianPeriod,) = sf.gda.isPatricianPeriodNow(superToken, address(distributor));
+        LiquidationExpectations memory expectations =
+            _getLiquidationExpectations(address(distributor), address(liquidator), singleDeposit, isPatricianPeriod);
 
-        // then we ensure that the sender has a critical balance
-        (int256 availableBalance,,,) = superToken.realtimeBalanceOfNow(address(distributor));
-        bool isDistributorCritical = availableBalance < 0;
+        if (!(flowExists && expectations.isCritical)) return;
 
-        // if both conditions are met, a liquidation should occur without fail
-        bool isLiquidationValid = flowExists && isDistributorCritical;
-        if (isLiquidationValid) {
-            // solhint-disable-next-line no-empty-blocks
-            try liquidator.gdaLiquidate(address(distributor), pool) {}
-            catch {
-                liquidationFails = true;
+        try liquidator.gdaLiquidate(address(distributor), pool) {
+            if (superToken.getFlowDistributionFlowRate(address(distributor), pool) != 0) {
+                liquidationPostconditionViolated = true;
+            } else if (!_checkLiquidationBalances(expectations, address(liquidator))) {
+                liquidationPostconditionViolated = true;
             }
+        } catch {
+            liquidationFails = true;
         }
     }
 

--- a/packages/hot-fuzz/contracts/superfluid-tests/SuperHotFuzz.sol
+++ b/packages/hot-fuzz/contracts/superfluid-tests/SuperHotFuzz.sol
@@ -1,13 +1,26 @@
 // SPDX-License-Identifier: AGPLv3
 pragma solidity >= 0.8.0;
 
+import {ISuperfluidPool} from
+    "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/gdav1/ISuperfluidPool.sol";
+import {PoolConfig} from
+    "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/gdav1/IGeneralDistributionAgreementV1.sol";
 import "./ConstantFlowAgreementV1.hott.sol";
 import "./GeneralDistributionAgreementV1.hott.sol";
 import "./SuperToken.hott.sol";
 
 // Combine all the hot fuzzes
 contract SuperHotFuzz is HotFuzzBase(10), CFAHotFuzzMixin, GDAHotFuzzMixin, SuperTokenHotFuzzMixin {
+    uint256 public constant NUM_INITIAL_POOLS = 3;
+
     constructor() {
         _initTesters();
+
+        PoolConfig memory config = PoolConfig({transferabilityForUnitsOwner: true, distributionFromAnyAddress: true});
+        for (uint256 i; i < NUM_INITIAL_POOLS; i++) {
+            SuperfluidTester tester = _getOneTester(uint8(i));
+            ISuperfluidPool pool = tester.createPool(address(tester), config);
+            _addPool(pool);
+        }
     }
 }


### PR DESCRIPTION
CFA and GDA liquidation previously used the agreement-local deposit to decide coverage, patrician period, and reward split. Mixed CFA+GDA positions could therefore be treated as uncovered (and bailed out) even when the account still had enough total deposit.

This uses account-level `totalDeposit` from `realtimeBalanceOf` instead. Same changeset as the v1.15.0 hotfix already deployed on mainnets.