### PR TITLE
Require lockfile and syncpack checks on feature PRs

### DIFF
--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -64,6 +64,11 @@ jobs:
           npm run lint:shellcheck
           npm run lint:actionlint
 
+      - name: Workspace consistency
+        run: |
+          yarn install --immutable --mode=skip-build
+          yarn lint:syncpack
+
       - name: Create build set
         run: tasks/create-build-set.sh ${{ github.sha }} dev origin
 
@@ -158,7 +163,8 @@ jobs:
 
     if: always()
 
-    needs: [ test-spec-haskell
+    needs: [ check
+           , test-spec-haskell
            , test-solidity-semantic-money
            , test-ethereum-contracts, coverage-ethereum-contracts
            , test-hot-fuzz
@@ -181,6 +187,8 @@ jobs:
               echo "Passed."
             fi
           }
+          echo "Checking if the job \"check\" passes..."
+          test "${{ needs.check.result }}" == "success"
           check_result spec-haskell ${{ needs.test-spec-haskell.result }}
           check_result solidity-semantic-money ${{ needs.test-solidity-semantic-money.result }}
           check_result test-ethereum-contracts ${{ needs.test-ethereum-contracts.result }}

--- a/flake.nix
+++ b/flake.nix
@@ -179,10 +179,12 @@
           buildInputs = [ mk-cache-key-pkg ];
         };
 
+        # Node/Yarn only — no foundry/solc. Always-on feature-branch check job.
         devShells.ci-minimum = mkShell {
           buildInputs =
             with pkgs;
             ciInputs
+            ++ defaultNodeDevInputs
             ++ [
               actionlint
               shellcheck

--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -4,7 +4,7 @@
     "version": "0.3.0",
     "devDependencies": {
         "@superfluid-finance/ethereum-contracts": "^1.15.2",
-        "@superfluid-finance/metadata": "^1.6.3"
+        "@superfluid-finance/metadata": "^1.6.4"
     },
     "license": "MIT",
     "scripts": {

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -4,7 +4,7 @@
     "version": "1.3.0",
     "devDependencies": {
         "@superfluid-finance/ethereum-contracts": "^1.15.2",
-        "@superfluid-finance/metadata": "^1.6.3"
+        "@superfluid-finance/metadata": "^1.6.4"
     },
     "license": "MIT",
     "scripts": {

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -19,7 +19,7 @@
         "@safe-global/safe-service-client": "^2.0.3",
         "@safe-global/safe-web3-lib": "^1.9.4",
         "@superfluid-finance/js-sdk": "^0.6.3",
-        "@superfluid-finance/metadata": "^1.6.3",
+        "@superfluid-finance/metadata": "^1.6.4",
         "async": "^3.2.6",
         "csv-writer": "^1.6.0",
         "ethers": "^5.8.0",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -7,7 +7,7 @@
         "path": false
     },
     "dependencies": {
-        "@superfluid-finance/metadata": "^1.6.3",
+        "@superfluid-finance/metadata": "^1.6.4",
         "@truffle/contract": "4.6.31",
         "auto-bind": "4.0.0",
         "node-fetch": "2.7.0"

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -5,7 +5,7 @@
     "bugs": "https://github.com/superfluid-org/protocol-monorepo/issues",
     "dependencies": {
         "@superfluid-finance/ethereum-contracts": "1.15.2",
-        "@superfluid-finance/metadata": "^1.6.3",
+        "@superfluid-finance/metadata": "^1.6.4",
         "graphql-request": "6.1.0",
         "lodash": "4.18.1",
         "tsify": "5.0.4"

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -9,7 +9,7 @@
         "mustache": "4.2.0"
     },
     "devDependencies": {
-        "@superfluid-finance/metadata": "^1.6.3",
+        "@superfluid-finance/metadata": "^1.6.4",
         "coingecko-api": "^1.0.10",
         "graphql": "^16.12.0",
         "graphql-request": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5452,7 +5452,7 @@ __metadata:
     "@safe-global/safe-service-client": "npm:^2.0.3"
     "@safe-global/safe-web3-lib": "npm:^1.9.4"
     "@superfluid-finance/js-sdk": "npm:^0.6.3"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
     "@truffle/contract": "npm:4.6.31"
     async: "npm:^3.2.6"
     csv-writer: "npm:^1.6.0"
@@ -5490,7 +5490,7 @@ __metadata:
   resolution: "@superfluid-finance/js-sdk@workspace:packages/js-sdk"
   dependencies:
     "@superfluid-finance/ethereum-contracts": "npm:^1.15.2"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
     "@truffle/contract": "npm:4.6.31"
     auto-bind: "npm:4.0.0"
     chai-as-promised: "npm:^8.0.2"
@@ -5501,7 +5501,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@superfluid-finance/metadata@npm:^1.6.3, @superfluid-finance/metadata@workspace:packages/metadata":
+"@superfluid-finance/metadata@npm:^1.6.4, @superfluid-finance/metadata@workspace:packages/metadata":
   version: 0.0.0-use.local
   resolution: "@superfluid-finance/metadata@workspace:packages/metadata"
   languageName: unknown
@@ -5515,7 +5515,7 @@ __metadata:
     "@graphql-codegen/near-operation-file-preset": "npm:^3.1.0"
     "@graphql-typed-document-node/core": "npm:^3.2.0"
     "@superfluid-finance/ethereum-contracts": "npm:1.15.2"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
     ajv: "npm:^8.17.1"
     browserify: "npm:^17.0.1"
     ethers: "npm:^5.8.0"
@@ -5565,7 +5565,7 @@ __metadata:
   dependencies:
     "@graphprotocol/graph-cli": "npm:0.98.1"
     "@graphprotocol/graph-ts": "npm:0.38.2"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
     "@superfluid-finance/sdk-core": "npm:0.9.0"
     coingecko-api: "npm:^1.0.10"
     graphql: "npm:^16.12.0"
@@ -8277,7 +8277,7 @@ __metadata:
   resolution: "autowrap@workspace:packages/automation-contracts/autowrap"
   dependencies:
     "@superfluid-finance/ethereum-contracts": "npm:^1.15.2"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
   languageName: unknown
   linkType: soft
 
@@ -22447,7 +22447,7 @@ __metadata:
   resolution: "scheduler@workspace:packages/automation-contracts/scheduler"
   dependencies:
     "@superfluid-finance/ethereum-contracts": "npm:^1.15.2"
-    "@superfluid-finance/metadata": "npm:^1.6.3"
+    "@superfluid-finance/metadata": "npm:^1.6.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- Run `yarn install --immutable` and syncpack on the always-on feature-branch `check` job, and fail the merge aggregator if that job does not succeed.
- This is the class of failure #2218 left on `dev`: PR CI skipped the jobs that run syncpack, so a metadata version bump merged green and went red after merge.
- Also align consumer `@superfluid-finance/metadata` ranges to `^1.6.4` (and `yarn.lock`) so current `dev` passes the new check.

Does not run the full package test matrix on metadata-only PRs.

## Test plan
- [ ] Confirm the new `Workspace consistency` step runs on this PR and passes
- [ ] Confirm `All packages tested (Feature Branch)` fails if `check` fails (not skipped)
- [ ] Confirm a docs-only / haskell-only PR still skips heavy package tests