### PR TITLE
[ETHEREUM-CONTRACTS] Soft-freeze IDA except Optimism

### DIFF
--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -12,6 +12,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   These were added in v1.4.3, but the necessary steps to make this feature available and useful were never taken.
   In order to not confuse devs (human or non), this part of the API is therefore removed.
   The reserved storage mapping is renamed to `_canonicalWrapperSuperTokensDeprecated` (slot preserved for UUPS upgrade safety).
+- `InstantDistributionAgreementV1` constructor is now `(host, newActivityFrozen, maxNumSubscriptions)`.
+  `MAX_NUM_SUBSCRIPTIONS` is an immutable (was a constant).
+
+### Changed
+
+- IDA soft-freeze: `deploy-framework.js` freezes new activity (`createIndex` / `updateIndex` / `distribute` / `updateSubscription`) on all networks except Optimism mainnet and Optimism Sepolia.
+  Unwind ops (`claim`, `approveSubscription`, `revokeSubscription`, `deleteSubscription`) stay available.
+  On remaining IDA-enabled networks the approved-subscription cap is 32 (was 256). Frozen networks keep the 256 cap so existing high-slot accounts can still unwind.
 
 ## [v1.15.2]
 

--- a/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
@@ -19,6 +19,8 @@ import { AgreementLibrary } from "./AgreementLibrary.sol";
  * @author Superfluid
  * @dev Please read IInstantDistributionAgreementV1 for implementation notes.
  * @dev For more technical notes, please visit protocol-monorepo wiki area.
+ * @dev New activity can be frozen per logic deployment via constructor immutables
+ *      (`NEW_ACTIVITY_FROZEN`, `MAX_NUM_SUBSCRIPTIONS`). Unwind ops stay available.
  *
  * Storage Layout Notes
  * Agreement State
@@ -69,8 +71,14 @@ contract InstantDistributionAgreementV1 is
 
     address public constant SLOTS_BITMAP_LIBRARY_ADDRESS = address(SlotsBitmapLibrary);
 
-    /// @dev Maximum number of subscriptions a subscriber can have
-    uint32 public constant MAX_NUM_SUBSCRIPTIONS = SlotsBitmapLibrary._MAX_NUM_SLOTS;
+    /// @notice When true, createIndex/updateIndex/distribute/updateSubscription revert.
+    ///         Unwind ops (claim, approve, revoke, delete) remain available.
+    bool public immutable NEW_ACTIVITY_FROZEN;
+
+    /// @notice Cap on newly approved subscriptions per subscriber.
+    /// @dev Listing still iterates the 256-bit slots bitmap, so subscriptions that already
+    ///      exist above this cap remain visible in realtimeBalanceOf after an upgrade.
+    uint32 public immutable MAX_NUM_SUBSCRIPTIONS;
 
     /// @dev Subscriber state slot id for storing subs bitmap
     uint256 private constant _SUBSCRIBER_SUBS_BITMAP_STATE_SLOT_ID = 0;
@@ -82,8 +90,23 @@ contract InstantDistributionAgreementV1 is
     /// @dev A special id that indicating the subscription is not approved yet
     uint32 private constant _UNALLOCATED_SUB_ID = type(uint32).max;
 
-    // solhint-disable-next-line no-empty-blocks
-    constructor(ISuperfluid host) AgreementBase(address(host)) {}
+    constructor(
+        ISuperfluid host,
+        bool newActivityFrozen,
+        uint32 maxNumSubscriptions
+    )
+        AgreementBase(address(host))
+    {
+        if (maxNumSubscriptions == 0 || maxNumSubscriptions > SlotsBitmapLibrary._MAX_NUM_SLOTS) {
+            revert IDA_INVALID_MAX_NUM_SUBSCRIPTIONS();
+        }
+        NEW_ACTIVITY_FROZEN = newActivityFrozen;
+        MAX_NUM_SUBSCRIPTIONS = maxNumSubscriptions;
+    }
+
+    function _requireNewActivityEnabled() private view {
+        if (NEW_ACTIVITY_FROZEN) revert IDA_NEW_ACTIVITY_FROZEN();
+    }
 
     /// @dev Agreement data for the index
     struct IndexData {
@@ -170,6 +193,7 @@ contract InstantDistributionAgreementV1 is
         external override
         returns(bytes memory newCtx)
     {
+        _requireNewActivityEnabled();
         ISuperfluid.Context memory context = AgreementLibrary.authorizeTokenAccess(token, ctx);
         address publisher = context.msgSender;
         bytes32 iId = _getPublisherId(publisher, indexId);
@@ -240,6 +264,7 @@ contract InstantDistributionAgreementV1 is
         external override
         returns(bytes memory newCtx)
     {
+        _requireNewActivityEnabled();
         ISuperfluid.Context memory context = AgreementLibrary.authorizeTokenAccess(token, ctx);
         address publisher = context.msgSender;
         (bytes32 iId, IndexData memory idata) = _loadIndexData(token, publisher, indexId);
@@ -261,6 +286,7 @@ contract InstantDistributionAgreementV1 is
         external override
         returns(bytes memory newCtx)
     {
+        _requireNewActivityEnabled();
         ISuperfluid.Context memory context = AgreementLibrary.authorizeTokenAccess(token, ctx);
         address publisher = context.msgSender;
         (bytes32 iId, IndexData memory idata) = _loadIndexData(token, publisher, indexId);
@@ -517,6 +543,7 @@ contract InstantDistributionAgreementV1 is
         external override
         returns(bytes memory newCtx)
     {
+        _requireNewActivityEnabled();
         if (subscriber == address(0)) {
             revert IDA_ZERO_ADDRESS_SUBSCRIBER();
         }
@@ -1109,6 +1136,13 @@ contract InstantDistributionAgreementV1 is
         private
         returns (uint32 subId)
     {
+        uint256 nUsed = SlotsBitmapLibrary.countUsedSlots(
+            token,
+            subscriber,
+            _SUBSCRIBER_SUBS_BITMAP_STATE_SLOT_ID);
+        if (nUsed >= MAX_NUM_SUBSCRIPTIONS) {
+            revert IDA_TOO_MANY_SUBSCRIPTIONS();
+        }
         return SlotsBitmapLibrary.findEmptySlotAndFill(
             token,
             subscriber,

--- a/packages/ethereum-contracts/contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol
@@ -47,6 +47,9 @@ abstract contract IInstantDistributionAgreementV1 is ISuperAgreement {
     error IDA_SUBSCRIPTION_IS_NOT_APPROVED();  // 0x37412573
     error IDA_INSUFFICIENT_BALANCE();          // 0x16e759bb
     error IDA_ZERO_ADDRESS_SUBSCRIBER();       // 0xc90a4674
+    error IDA_NEW_ACTIVITY_FROZEN();           // 0xace0382a
+    error IDA_TOO_MANY_SUBSCRIPTIONS();        // 0x6db410ea
+    error IDA_INVALID_MAX_NUM_SUBSCRIPTIONS(); // 0xd88c9dfa
 
     /// @dev ISuperAgreement.agreementType implementation
     function agreementType() external override pure returns (bytes32) {

--- a/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.t.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.t.sol
@@ -356,7 +356,7 @@ library SuperfluidIDAv1DeployerLibrary {
         external
         returns (InstantDistributionAgreementV1)
     {
-        return new InstantDistributionAgreementV1(_host);
+        return new InstantDistributionAgreementV1(_host, false, 256);
     }
 }
 

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -158,6 +158,10 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
     console.log("chain ID: ", chainId);
     console.log("deployer: ", deployerAddr);
     const config = getConfig(chainId);
+    const idaNewActivityFrozen = !!config.idaNewActivityFrozen;
+    const idaMaxNumSubscriptions = Number(config.idaMaxNumSubscriptions);
+    console.log("IDA new activity frozen: ", idaNewActivityFrozen);
+    console.log("IDA max num subscriptions: ", idaMaxNumSubscriptions);
 
     if (config.isTestnet) {
         output += "IS_TESTNET=1\n";
@@ -567,7 +571,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         const agreement = await web3tx(
             InstantDistributionAgreementV1.new,
             "InstantDistributionAgreementV1.new"
-        )(superfluid.address);
+        )(superfluid.address, idaNewActivityFrozen, idaMaxNumSubscriptions);
         console.log(
             "New InstantDistributionAgreementV1 address",
             agreement.address
@@ -910,6 +914,16 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
             agreementsToUpdate.push(cfaNewLogicAddress);
         }
         // deploy new IDA logic
+        // Constructor immutables are baked into bytecode. Include them in replacements so
+        // consecutive upgrades with the same chain config do not look like a code change,
+        // and a different chain's freeze/max settings cannot accidentally match.
+        const idaCodeReplacements = [ superfluidConstructorParam ];
+        if (idaNewActivityFrozen) {
+            idaCodeReplacements.push("1".padStart(64, "0"));
+        }
+        idaCodeReplacements.push(
+            BigInt(idaMaxNumSubscriptions).toString(16).padStart(64, "0")
+        );
         const idaNewLogicAddress = await deployContractIfCodeChanged(
             web3,
             InstantDistributionAgreementV1,
@@ -919,7 +933,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 )
             ).getCodeAddress(),
             async () => (await deployIDAv1()).address,
-            [ superfluidConstructorParam ]
+            idaCodeReplacements
         );
         if (idaNewLogicAddress !== ZERO_ADDRESS) {
             agreementsToUpdate.push(idaNewLogicAddress);

--- a/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
+++ b/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
@@ -10,14 +10,30 @@ module.exports = function getConfig(chainId) {
             // for local testing (hardhat node default chainId)
             // this is a fake forwarder address, it is to test the deployment script
             trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
+            // Keep IDA fully usable in unit tests.
+            idaNewActivityFrozen: false,
+            idaMaxNumSubscriptions: 256,
         },
         6777: {
             // for coverage testing
             // this is a fake forwarder address, it is to test the deployment script
             trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
+            idaNewActivityFrozen: false,
+            idaMaxNumSubscriptions: 256,
         },
 
         // persistent chains
+
+        // optimism-mainnet — IDA remains enabled; cap approved slots at 32
+        10: {
+            idaNewActivityFrozen: false,
+            idaMaxNumSubscriptions: 32,
+        },
+        // optimism-sepolia
+        11155420: {
+            idaNewActivityFrozen: false,
+            idaMaxNumSubscriptions: 32,
+        },
 
         // eth-mainnet
         1: {
@@ -80,6 +96,11 @@ module.exports = function getConfig(chainId) {
         resolverAddress: global?.process.env.RESOLVER_ADDRESS || sfNw?.contractsV1?.resolver,
         trustedForwarders: sfNw?.trustedForwarders,
         appCallbackGasLimit: 15000000,
+        // Freeze IDA new activity by default. Optimism (+ op sepolia) override in EXTRA_CONFIG.
+        // Frozen networks keep max=256 so existing subscribers with >32 approved slots can
+        // still unwind (approve remaining pending) without hitting a tighter cap.
+        idaNewActivityFrozen: true,
+        idaMaxNumSubscriptions: 256,
         ...EXTRA_CONFIG[chainId]
     };
 };

--- a/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
+++ b/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
@@ -13,6 +13,8 @@ contract SuperfluidFrameworkDeployerTest is FoundrySuperfluidTester {
         assertTrue(address(sf.host) != address(0), "SFDeployer: host not deployed");
         assertTrue(address(sf.cfa) != address(0), "SFDeployer: cfa not deployed");
         assertTrue(address(sf.ida) != address(0), "SFDeployer: ida not deployed");
+        assertFalse(sf.ida.NEW_ACTIVITY_FROZEN(), "SFDeployer: test IDA should not be frozen");
+        assertEq(sf.ida.MAX_NUM_SUBSCRIPTIONS(), 256, "SFDeployer: test IDA max slots");
         assertTrue(address(sf.gda) != address(0), "SFDeployer: gda not deployed");
         assertTrue(address(sf.superTokenFactory) != address(0), "SFDeployer: superTokenFactory not deployed");
         assertTrue(address(sf.superTokenLogic) != address(0), "SFDeployer: superTokenLogic not deployed");

--- a/packages/ethereum-contracts/test/foundry/agreements/InstantDistributionAgreementV1.Freeze.t.sol
+++ b/packages/ethereum-contracts/test/foundry/agreements/InstantDistributionAgreementV1.Freeze.t.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity ^0.8.23;
+
+import { FoundrySuperfluidTester } from "../FoundrySuperfluidTester.t.sol";
+import {
+    IInstantDistributionAgreementV1
+} from "../../../contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol";
+import { InstantDistributionAgreementV1 } from "../../../contracts/agreements/InstantDistributionAgreementV1.sol";
+
+/// @notice Soft-freeze and per-deployment slot-cap tests for IDA.
+/// @dev Foundry framework deploys unfrozen IDA with max=256. Production freeze/cap is applied
+///      by upgrading logic (same path as deploy-framework.js).
+contract InstantDistributionAgreementV1FreezeTest is FoundrySuperfluidTester {
+    bytes internal constant EMPTY = "";
+    uint32 internal constant INDEX_A = 0;
+    uint32 internal constant INDEX_B = 1;
+    uint128 internal constant ONE_UNIT = 1;
+    uint256 internal constant DIST_AMOUNT = 100e18;
+
+    constructor() FoundrySuperfluidTester(3) { }
+
+    function _idaCall(bytes memory callData) internal {
+        sf.host.callAgreement(sf.ida, callData, EMPTY);
+    }
+
+    function _createIndex(address publisher, uint32 indexId) internal {
+        vm.startPrank(publisher);
+        _idaCall(abi.encodeCall(sf.ida.createIndex, (superToken, indexId, EMPTY)));
+        vm.stopPrank();
+    }
+
+    function _updateSubscription(address publisher, uint32 indexId, address subscriber, uint128 units) internal {
+        vm.startPrank(publisher);
+        _idaCall(abi.encodeCall(sf.ida.updateSubscription, (superToken, indexId, subscriber, units, EMPTY)));
+        vm.stopPrank();
+    }
+
+    function _approve(address subscriber, address publisher, uint32 indexId) internal {
+        vm.startPrank(subscriber);
+        _idaCall(abi.encodeCall(sf.ida.approveSubscription, (superToken, publisher, indexId, EMPTY)));
+        vm.stopPrank();
+    }
+
+    function _distribute(address publisher, uint32 indexId, uint256 amount) internal {
+        vm.startPrank(publisher);
+        _idaCall(abi.encodeCall(sf.ida.distribute, (superToken, indexId, amount, EMPTY)));
+        vm.stopPrank();
+    }
+
+    function _upgradeIda(bool frozen, uint32 maxSubs) internal {
+        // Foundry's test host is non-upgradable, so governance.updateAgreementClass reverts.
+        // Etching the deployed IDA address with new logic bytecode is equivalent to a UUPS
+        // logic swap: IDA is stateless, all index/subscription data lives on the Super Token.
+        InstantDistributionAgreementV1 newLogic = new InstantDistributionAgreementV1(sf.host, frozen, maxSubs);
+        vm.etch(address(sf.ida), address(newLogic).code);
+    }
+
+    function _expectFrozen(bytes memory callData) internal {
+        vm.expectRevert(IInstantDistributionAgreementV1.IDA_NEW_ACTIVITY_FROZEN.selector);
+        _idaCall(callData);
+    }
+
+    function testDefaultTestDeploymentIsUnfrozenWith256Slots() public view {
+        assertFalse(sf.ida.NEW_ACTIVITY_FROZEN());
+        assertEq(sf.ida.MAX_NUM_SUBSCRIPTIONS(), 256);
+    }
+
+    function testConstructorRejectsInvalidMax() public {
+        vm.expectRevert(IInstantDistributionAgreementV1.IDA_INVALID_MAX_NUM_SUBSCRIPTIONS.selector);
+        new InstantDistributionAgreementV1(sf.host, false, 0);
+
+        vm.expectRevert(IInstantDistributionAgreementV1.IDA_INVALID_MAX_NUM_SUBSCRIPTIONS.selector);
+        new InstantDistributionAgreementV1(sf.host, false, 257);
+    }
+
+    function testFreezeRevertsNewActivityAndKeepsUnwind() public {
+        _createIndex(alice, INDEX_A);
+        _updateSubscription(alice, INDEX_A, bob, ONE_UNIT);
+        _updateSubscription(alice, INDEX_A, admin, ONE_UNIT);
+        _approve(admin, alice, INDEX_A);
+        _distribute(alice, INDEX_A, DIST_AMOUNT);
+
+        (,,, uint256 pendingBob) = sf.ida.getSubscription(superToken, alice, INDEX_A, bob);
+        assertEq(pendingBob, DIST_AMOUNT / 2, "pending should be half of distribution");
+
+        (int256 bobAvailBefore,,,) = superToken.realtimeBalanceOfNow(bob);
+        (, uint256 aliceDepositBefore,,) = superToken.realtimeBalanceOfNow(alice);
+        assertGt(aliceDepositBefore, 0, "publisher should hold pending deposit");
+
+        _upgradeIda(true, 256);
+        assertTrue(sf.ida.NEW_ACTIVITY_FROZEN());
+        assertEq(sf.ida.MAX_NUM_SUBSCRIPTIONS(), 256);
+        assertEq(sf.ida.agreementType(), keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1"));
+
+        vm.startPrank(alice);
+        _expectFrozen(abi.encodeCall(sf.ida.createIndex, (superToken, INDEX_B, EMPTY)));
+        _expectFrozen(abi.encodeCall(sf.ida.updateIndex, (superToken, INDEX_A, uint128(1e18), EMPTY)));
+        _expectFrozen(abi.encodeCall(sf.ida.distribute, (superToken, INDEX_A, uint256(1e18), EMPTY)));
+        _expectFrozen(abi.encodeCall(sf.ida.updateSubscription, (superToken, INDEX_A, bob, uint128(2), EMPTY)));
+        vm.stopPrank();
+
+        // Unwind: claim pending for bob (anyone can claim)
+        vm.prank(alice);
+        _idaCall(abi.encodeCall(sf.ida.claim, (superToken, alice, INDEX_A, bob, EMPTY)));
+
+        (,,, uint256 pendingBobAfter) = sf.ida.getSubscription(superToken, alice, INDEX_A, bob);
+        assertEq(pendingBobAfter, 0);
+
+        (int256 bobAvailAfter,,,) = superToken.realtimeBalanceOfNow(bob);
+        assertEq(uint256(int256(bobAvailAfter - bobAvailBefore)), DIST_AMOUNT / 2);
+
+        (, uint256 aliceDepositAfterClaim,,) = superToken.realtimeBalanceOfNow(alice);
+        assertLt(aliceDepositAfterClaim, aliceDepositBefore);
+
+        // Unwind: approve remaining pending (bob already claimed; re-create pending via... bob is still pending 0)
+        // admin is already approved — revoke then publisher-delete
+        vm.prank(admin);
+        _idaCall(abi.encodeCall(sf.ida.revokeSubscription, (superToken, alice, INDEX_A, EMPTY)));
+
+        vm.prank(alice);
+        _idaCall(abi.encodeCall(sf.ida.deleteSubscription, (superToken, alice, INDEX_A, bob, EMPTY)));
+
+        (bool bobExists,,,) = sf.ida.getSubscription(superToken, alice, INDEX_A, bob);
+        assertFalse(bobExists);
+
+        // Approved subscriber dynamic balance still spends after freeze (admin received half)
+        (int256 adminAvail,,,) = superToken.realtimeBalanceOfNow(admin);
+        assertGe(adminAvail, int256(DIST_AMOUNT / 2));
+    }
+
+    function testConsecutiveFrozenUpgradesStayFrozen() public {
+        _createIndex(alice, INDEX_A);
+        _upgradeIda(true, 256);
+        _upgradeIda(true, 256);
+        assertTrue(sf.ida.NEW_ACTIVITY_FROZEN());
+        vm.prank(alice);
+        _expectFrozen(abi.encodeCall(sf.ida.createIndex, (superToken, INDEX_B, EMPTY)));
+    }
+
+    function testMax32AllowsThirtyTwoApprovalsAndRevertsThirtyThird() public {
+        _upgradeIda(false, 32);
+        assertFalse(sf.ida.NEW_ACTIVITY_FROZEN());
+        assertEq(sf.ida.MAX_NUM_SUBSCRIPTIONS(), 32);
+
+        for (uint32 i = 0; i < 32; ++i) {
+            _createIndex(alice, i);
+            _updateSubscription(alice, i, bob, ONE_UNIT);
+            _approve(bob, alice, i);
+        }
+
+        (address[] memory publishers,,) = sf.ida.listSubscriptions(superToken, bob);
+        assertEq(publishers.length, 32);
+
+        _createIndex(alice, 32);
+        _updateSubscription(alice, 32, bob, ONE_UNIT);
+        vm.startPrank(bob);
+        vm.expectRevert(IInstantDistributionAgreementV1.IDA_TOO_MANY_SUBSCRIPTIONS.selector);
+        _idaCall(abi.encodeCall(sf.ida.approveSubscription, (superToken, alice, uint32(32), EMPTY)));
+        vm.stopPrank();
+
+        // Existing 32 approved slots still contribute to realtime balance after a distribution
+        _distribute(alice, 0, DIST_AMOUNT);
+        (int256 bobDynamic, uint256 deposit,) = sf.ida.realtimeBalanceOf(superToken, bob, block.timestamp);
+        assertEq(uint256(bobDynamic), DIST_AMOUNT);
+        assertEq(deposit, 0);
+    }
+
+    function testApproveAfterFreezeSettlesPendingIntoSubscriberBalance() public {
+        _createIndex(alice, INDEX_A);
+        _updateSubscription(alice, INDEX_A, bob, ONE_UNIT);
+        _distribute(alice, INDEX_A, DIST_AMOUNT);
+
+        (int256 bobBefore,,,) = superToken.realtimeBalanceOfNow(bob);
+        _upgradeIda(true, 256);
+
+        _approve(bob, alice, INDEX_A);
+
+        (bool exist, bool approved, uint128 units, uint256 pending) =
+            sf.ida.getSubscription(superToken, alice, INDEX_A, bob);
+        assertTrue(exist);
+        assertTrue(approved);
+        assertEq(units, ONE_UNIT);
+        assertEq(pending, 0);
+
+        (int256 bobAfter,,,) = superToken.realtimeBalanceOfNow(bob);
+        assertEq(uint256(int256(bobAfter - bobBefore)), DIST_AMOUNT);
+    }
+}

--- a/packages/ethereum-contracts/test/ops-scripts/deployment.test.js
+++ b/packages/ethereum-contracts/test/ops-scripts/deployment.test.js
@@ -6,6 +6,7 @@ const deployTestToken = require("../../ops-scripts/deploy-test-token");
 const deploySuperToken = require("../../ops-scripts/deploy-super-token");
 const deployTestEnvironment = require("../../ops-scripts/deploy-test-environment");
 const deployAuxContracts = require("../../ops-scripts/deploy-aux-contracts");
+const getConfig = require("../../ops-scripts/libs/getConfig");
 const {expect} = require("chai");
 const Resolver = artifacts.require("Resolver");
 const TestToken = artifacts.require("TestToken");
@@ -118,6 +119,31 @@ contract("Embedded deployment scripts", (accounts) => {
         assert.isTrue(await s.superfluid.isAgreementTypeListed.call(idaV1Type));
         return s;
     }
+
+    it("IDA freeze config is chain-dependent without env vars", () => {
+        const optimism = getConfig(10);
+        assert.isFalse(optimism.idaNewActivityFrozen, "optimism-mainnet should keep IDA enabled");
+        assert.equal(optimism.idaMaxNumSubscriptions, 32);
+
+        const opSepolia = getConfig(11155420);
+        assert.isFalse(opSepolia.idaNewActivityFrozen, "optimism-sepolia should keep IDA enabled");
+        assert.equal(opSepolia.idaMaxNumSubscriptions, 32);
+
+        const polygon = getConfig(137);
+        assert.isTrue(polygon.idaNewActivityFrozen, "polygon should freeze IDA new activity");
+        assert.equal(polygon.idaMaxNumSubscriptions, 256);
+
+        const ethereum = getConfig(1);
+        assert.isTrue(ethereum.idaNewActivityFrozen);
+        assert.equal(ethereum.idaMaxNumSubscriptions, 256);
+
+        const base = getConfig(8453);
+        assert.isTrue(base.idaNewActivityFrozen);
+
+        const local = getConfig(31337);
+        assert.isFalse(local.idaNewActivityFrozen, "local tests keep IDA fully usable");
+        assert.equal(local.idaMaxNumSubscriptions, 256);
+    });
 
     it("codeChanged function", async () => {
         {


### PR DESCRIPTION
## Summary
- Soft-freeze IDA new activity (`createIndex` / `updateIndex` / `distribute` / `updateSubscription`) on all networks except Optimism mainnet and Optimism Sepolia. Unwind ops (`claim`, `approveSubscription`, `revokeSubscription`, `deleteSubscription`) stay available so existing indexes can be settled.
- Remaining IDA-enabled networks get a 32 approved-subscription cap (was 256). Frozen networks keep 256 so accounts that already have more than 32 slots can still unwind.
- Freeze/max are constructor immutables wired through `getConfig.js` + `deploy-framework.js`, so a later upgrade with the same chain config will not look like a code change and cannot unfreeze.

IDA is still listed on every Host. Unlisting it would break Super Token `realtimeBalanceOf` for leftover publisher deposits and approved subscriber balances.

## Test plan
Foundry freeze/unwind/cap suite plus `getConfig` chain-matrix coverage. Local Hardhat deployments stay unfrozen so existing IDA tests remain usable.